### PR TITLE
use https and omit port in email link in production

### DIFF
--- a/routes/api/v1/user/login.js
+++ b/routes/api/v1/user/login.js
@@ -96,11 +96,17 @@ const postRegister = async function(req, res){
           rejectUnauthorized: false
       }
     });
+
+    const link = 
+      process.env.NODE_ENV === "production" 
+      ? `https://${process.env.APP_HOST}${process.env.EMAIL_TOKEN_URL}?token=${savedUser.emailConfirmationToken}`
+      : `http://${process.env.APP_HOST}:${process.env.APP_PORT}${process.env.EMAIL_TOKEN_URL}?token=${savedUser.emailConfirmationToken}`      
+
     var mailOptions = {
         from: '"OpenBadges"'+email, // sender address
         to: savedUser.email, // list of receiver
         subject: 'Email verifizieren', // Subject line
-        html: '<b>Hallo '+user.firstname+' '+user.lastname+'</b><br><p>Dieser <a href="http://'+process.env.APP_HOST+':'+process.env.APP_PORT+process.env.EMAIL_TOKEN_URL+'?token='+savedUser.emailConfirmationToken+'">Link</a> ermöglicht das Verifizieren Ihrer Email-Adresse.<p>Liebe Grüße<br>Ihr OpenBadges-Team</p>' // html body
+        html: '<b>Hallo '+user.firstname+' '+user.lastname+'</b><br><p>Dieser <a href="' + link + '">Link</a> ermöglicht das Verifizieren Ihrer Email-Adresse.<p>Liebe Grüße<br>Ihr OpenBadges-Team</p>' // html body
     };
 
     // send mail with defined transport object
@@ -244,11 +250,17 @@ const requestResetPassword = async function (req, res){
             rejectUnauthorized: false
         }
       });
+
+      const link = 
+        process.env.NODE_ENV === "production" 
+        ? `https://${process.env.APP_HOST}${process.env.PASSWORD_TOKEN_URL}?token=${token}`
+        : `http://${process.env.APP_HOST}:${process.env.APP_PORT}${process.env.PASSWORD_TOKEN_URL}?token=${token}`      
+
       var mailOptions = {
           from: '"OpenBadges"'+email, // sender address
           to: user.email, // list of receiver
           subject: 'Passwort zurücksetzen', // Subject line
-          html: '<b>Hallo '+user.firstname+' '+user.lastname+'</b><br><p>Dieser <a href="http://'+process.env.APP_HOST+':'+process.env.APP_PORT+process.env.PASSWORD_TOKEN_URL+'?token='+token+'">Link</a> ermöglicht das Zurücksetzen des Passwortes.<br>Bitte beachten Sie, dass die Gültigkeit des Links auf 12 Stunden begrenzt ist.<p>Liebe Grüße<br>Ihr OpenBadges-Team</p>' // html body
+          html: '<b>Hallo '+user.firstname+' '+user.lastname+'</b><br><p>Dieser <a href="' + link + '">Link</a> ermöglicht das Zurücksetzen des Passwortes.<br>Bitte beachten Sie, dass die Gültigkeit des Links auf 12 Stunden begrenzt ist.<p>Liebe Grüße<br>Ihr OpenBadges-Team</p>' // html body
       };
 
       // send mail with defined transport object


### PR DESCRIPTION
When using `NODE_ENV=production` the emails need to have different links (https and omit port)